### PR TITLE
fixing clipped radar && negative raduis valus

### DIFF
--- a/src/radarChart.js
+++ b/src/radarChart.js
@@ -49,9 +49,9 @@ function displayRADAR(id, options, $element, layout, data, self) {
     allAxis = allAxis.slice(0 , axisTheshHold);
   }
   var total = allAxis.length;												//The number of different axes
-  var radius = Math.min(
-    (graphW/2) - (cfg.margin.left - cfg.margin.right),
-    (graphH/2) - (cfg.margin.top - cfg.margin.bottom)); 				//Radius of the outermost circle
+  var radius = Math.abs(Math.min(
+    (graphW/2) - cfg.margin.left - cfg.margin.right,
+    (graphH/2) - cfg.margin.top - cfg.margin.bottom)); 				//Radius of the outermost circle
   var angleSlice = Math.PI * 2 / total;									//The width in radians of each "slice"
 
   //Scale for the radius


### PR DESCRIPTION
fixing clipped radar by using Math.abs on the radius calculation
instead of parentheses to prevent negative values and console errors