### PR TITLE
[QPE 579] Improve handling invalid input & handle date 

### DIFF
--- a/src/paint.js
+++ b/src/paint.js
@@ -27,7 +27,6 @@ function paint ($element, layout) {
     labelFactor: 1.02, 																			//How much farther than the radius of the outer circle should the labels be placed
     wrapWidth: 50, 																				//The number of pixels after which a label needs to be given a new line
     strokeWidth: 2.8, 																			//The width of the stroke around each blob
-    //sortingCheck: checkSORTING(layout),															//The sorting configuration
     legendDisplay: layout.showLegend,															//Display the legend
     numberFormat: getFORMAT(layout)																//Format for number
   };
@@ -72,48 +71,8 @@ function getFORMAT(layout) {
   return result;
 }
 
-/*function checkSORTING(layout) {
-  var result = [];
-
-  // Detect if sorting is correct
-  if((layout.qHyperCube.qEffectiveInterColumnSortOrder[0] == 0) && (layout.qHyperCube.qEffectiveInterColumnSortOrder[1] == 1)) { result[0] = true; } else { result[0] = false; }
-
-  // Detect the browser language
-  switch (navigator.language.toUpperCase().split("-")[0]) {
-    case "FR":
-      result[1] = "Veuillez trier les dimensions et les mesures comme décrit ci-après :";				//FRENCH
-      break;
-    case "DE":
-      result[1] = "Sie ordnen die Abmessungen und die Maßnahmen, wie nachstehend beschrieben :";		//GERMAN
-      break;
-    case "ES":
-      result[1] = "Por favor, ordenar las dimensiones y medidas como se describe a continuación :";	//SPANISH
-      break;
-    default:
-      result[1] = "Please sort the dimensions and measures as described below :";						//ENGLISH
-      break;
-  }
-
-  // Build the  message
-  if(layout.qHyperCube.qSize.qcx == 3) {
-    result[2] = '<div style="position:relative; top:45%; text-align:center; font-size:15px">' + result[1] + '<p style="position:relative; padding-left:44%; text-align:left; font-size:14px"> 1. > &nbsp;' + layout.qHyperCube.qDimensionInfo[0].qFallbackTitle + "<br/> 2. > &nbsp;" + layout.qHyperCube.qDimensionInfo[1].qFallbackTitle + "<br/> 3. > &nbsp;" + layout.qHyperCube.qMeasureInfo[0].qFallbackTitle + '</p></div>';
-  } else {
-    result[2] = '<div style="position:relative; top:45%; text-align:center; font-size:15px">' + result[1] + '<p style="position:relative; padding-left:44%; text-align:left; font-size:14px"> 1. > &nbsp;' + layout.qHyperCube.qDimensionInfo[0].qFallbackTitle + "<br/> 2. > &nbsp;" + layout.qHyperCube.qMeasureInfo[0].qFallbackTitle + '</p></div>';
-  }
-
-  // Language detected
-  result[1] = navigator.language.toUpperCase().split("-")[0];
-
-  return result;
-}*/
-
 function convertHYPERCUBEtoJSON(layout) {
-// get qMatrix data array
   var qMatrix = layout.qHyperCube.qDataPages[0].qMatrix;
-
-  // create a new array that contains the measure labels
-
-  // create a new array that contains the dimensions and metric values
 
   var dim1Labels = qMatrix.map(function(d) {
     return d[0].qText;

--- a/src/paint.js
+++ b/src/paint.js
@@ -100,8 +100,8 @@ function convertHYPERCUBEtoJSON(layout) {
     return d[2].qNum;
   }) ;
 
-  const hasInvalidMetricValue = !!metric1Values.find(metricValue => isNaNOrStringNaN(metricValue));
-  const hasInvalidData = hasInvalidMetricValue;
+  const hasOnlyInvalidMetricValue = metric1Values.every(metricValue => isNaNOrStringNaN(metricValue));
+  const hasInvalidData = hasOnlyInvalidMetricValue;
   if (hasInvalidData) {
     return null;
   }
@@ -147,10 +147,7 @@ function convertHYPERCUBEtoJSON(layout) {
     actClassName = dim1Labels[k];
   }
   data[contdata] = myJson;
-  return {
-    data,
-    isValid: true
-  };
+  return data;
 }
 
 export default paint;

--- a/src/paint.js
+++ b/src/paint.js
@@ -141,6 +141,17 @@ function convertHYPERCUBEtoJSON(layout) {
     return d[2].qNum;
   }) ;
 
+  const hasInvalidMetricValue = !!metric1Values.find(metricValue => isNaNOrStringNaN(metricValue));
+  const hasAllValuesAsZeros = metric1Values.every(metricValue => metricValue === 0);
+  const hasInvalidData = hasInvalidMetricValue || hasAllValuesAsZeros;
+  if (hasInvalidData) {
+    return {
+      hasInvalidMetricValue,
+      hasAllValuesAsZeros,
+      isValid: false
+    };
+  }
+  
   // create a JSON array that contains dimensions and metric values
   var data = [];
   var actClassName = "";
@@ -182,7 +193,18 @@ function convertHYPERCUBEtoJSON(layout) {
     actClassName = dim1Labels[k];
   }
   data[contdata] = myJson;
-  return data;
+  return {
+    data,
+    isValid: true
+  };
 }
 
 export default paint;
+
+function isNaNOrStringNaN (input) {
+  if (!input) {
+    return false;
+  }
+  return isNaN(input) || input === 'NaN';
+}
+

--- a/src/paint.js
+++ b/src/paint.js
@@ -101,14 +101,9 @@ function convertHYPERCUBEtoJSON(layout) {
   }) ;
 
   const hasInvalidMetricValue = !!metric1Values.find(metricValue => isNaNOrStringNaN(metricValue));
-  const hasAllValuesAsZeros = metric1Values.every(metricValue => metricValue === 0);
-  const hasInvalidData = hasInvalidMetricValue || hasAllValuesAsZeros;
+  const hasInvalidData = hasInvalidMetricValue;
   if (hasInvalidData) {
-    return {
-      hasInvalidMetricValue,
-      hasAllValuesAsZeros,
-      isValid: false
-    };
+    return null;
   }
   
   // create a JSON array that contains dimensions and metric values

--- a/src/radarChart.js
+++ b/src/radarChart.js
@@ -80,18 +80,14 @@ function displayRADAR(className, options, $element, layout, input, self) {
   //Remove whatever chart with the same id/class was present before
   d3.select(id).select("svg").remove();
 
-  // Chart object id
-  var id = "container_" + layout.qInfo.qId;
+  const chartContainerElementId = "container_" + layout.qInfo.qId;
+ 
+  $element.empty()
+    .append(
+      $('<div />').attr("id", chartContainerElementId).width(cfg.size.width).height(cfg.size.height)
+    );
+  
 
-  // Check to see if the chart element has already been created
-  if (document.getElementById(id)) {
-    // if it has been created, empty its contents so we can redraw it
-    $("#" + id).empty();
-  }
-  else {
-    // if it hasn't been created, create it with the appropiate id and size
-    $element.append($('<div />').attr("id", id).width(cfg.size.width).height(cfg.size.height));
-  }
   var svg = d3.select("#" + id).append("svg")
     .attr("width", cfg.size.width)
     .attr("height", cfg.size.height)

--- a/src/radarChart.js
+++ b/src/radarChart.js
@@ -210,7 +210,7 @@ function displayRADAR(className, options, $element, layout, inputData, self) {
       });
       if(!isNull){
         // Select Value
-        self.backendApi.selectValues(0, [d[0].radar_areaclassName], true);
+        self.backendApi.selectValues(0, [d[0].radar_area_id], true);
       }
     })
     .on('mouseout', function(){
@@ -376,7 +376,7 @@ function displayRADAR(className, options, $element, layout, inputData, self) {
         .style("fill-opacity", 0.9);
 
       // Select Value
-      self.backendApi.selectValues(0, [data[d][0].radar_areaclassName], true);
+      self.backendApi.selectValues(0, [data[d][0].radar_area_id], true);
     }
   }
 

--- a/src/radarChart.js
+++ b/src/radarChart.js
@@ -11,10 +11,10 @@ import 'd3-svg-legend';
 
 const invalidMessageClassName = 'invalid-visualisation-message';
 
-function displayRADAR(className, options, $element, layout, input, self) {
-  const isInvalidVisualisation = !input.isValid;
+function displayRADAR(className, options, $element, layout, inputData, self) {
+  const isInvalidVisualisation = !inputData;
   if (isInvalidVisualisation) {
-    renderInvalidMessage($element, input);
+    renderInvalidMessage($element);
     return;
   }
 
@@ -35,7 +35,7 @@ function displayRADAR(className, options, $element, layout, input, self) {
   };
 
   // Convert the nested data passed in into an array of values arrays
-  var data = input.data.map(function(d) { return d.definition; });
+  var data = inputData.map(function(d) { return d.definition; });
 
   // Put all of the options into a variable called cfg
   if('undefined' !== typeof options){
@@ -492,14 +492,8 @@ Dual licensed under the MIT or GPL Version 2 licenses.
   }
 }
 
-function renderInvalidMessage ($element, { hasInvalidMetricValue, hasAllValuesAsZeros }) {
-  let errorMessage = '';
-  if (hasInvalidMetricValue) {
-    errorMessage = 'The chart is not displayed because there might be an error with the data or the measure.';
-  }
-  if (hasAllValuesAsZeros) {
-    errorMessage = 'The chart is not displayed because there are only zero values.';
-  }
+function renderInvalidMessage ($element) {
+  let errorMessage = 'The chart is not displayed because there might be an error with the data or the measure.';
   let invalidMessageElement = document.createElement('div');
   invalidMessageElement.className = invalidMessageClassName;
   invalidMessageElement.innerText = errorMessage;

--- a/src/radarChart.js
+++ b/src/radarChart.js
@@ -228,15 +228,6 @@ function displayRADAR(className, options, $element, layout, inputData, self) {
     .attr("class", "radarStroke")
     .attr("d", function(d) {
       return radarLine(d);
-
-      // d.map(e => {
-      //   if(!e.value.isNaN()){
-      //     return radarLine(d);
-      //   }
-      // });
-      // if(!d.value.isNaN())
-
-      // return radarLine(d);
     })
     .style("stroke-width", cfg.strokeWidth + "px")
     .style("stroke", function(d,i) { return cfg.color(i); })
@@ -314,7 +305,7 @@ function displayRADAR(className, options, $element, layout, inputData, self) {
     .text(function(d) { return format(options.numberFormat[0], (minValue + (maxValue - minValue) * d/cfg.levels)*options.numberFormat[1]) + options.numberFormat[2]; });
 
   /////////////////////////////////////////////////////////
-  /////////////////// Helper Function /////////////////////
+  /////////////////// Helper Functions /////////////////////
   /////////////////////////////////////////////////////////
 
   //Taken from http://bl.ocks.org/mbostock/7555321
@@ -344,6 +335,14 @@ function displayRADAR(className, options, $element, layout, inputData, self) {
       }
     });
   }//wrap
+
+  function renderInvalidMessage ($element) {
+    let errorMessage = 'The chart is not displayed because there might be an error with the data or the measure.';
+    let invalidMessageElement = document.createElement('div');
+    invalidMessageElement.className = invalidMessageClassName;
+    invalidMessageElement.innerText = errorMessage;
+    $element.empty().append(invalidMessageElement);
+  }
 
   // on mouseover for the legend symbol
   function cellover(d) {
@@ -489,14 +488,6 @@ Dual licensed under the MIT or GPL Version 2 licenses.
     v[1] = (m[1] && v[1])? Decimal+v[1] : "";
     return (isNegative?'-':'') + v[0] + v[1]; //put back any negation and combine integer and fraction.
   }
-}
-
-function renderInvalidMessage ($element) {
-  let errorMessage = 'The chart is not displayed because there might be an error with the data or the measure.';
-  let invalidMessageElement = document.createElement('div');
-  invalidMessageElement.className = invalidMessageClassName;
-  invalidMessageElement.innerText = errorMessage;
-  $element.empty().append(invalidMessageElement);
 }
   
 export default displayRADAR;

--- a/src/radarChart.js
+++ b/src/radarChart.js
@@ -31,20 +31,18 @@ function displayRADAR(className, options, $element, layout, input, self) {
     labelFactor: 1.25, 															//How much farther than the radius of the outer circle should the labels be placed
     wrapWidth: 100, 															//The number of pixels after which a label needs to be given a new line
     strokeWidth: 1.5, 															//The width of the stroke around each blob
-    //sortingCheck: [true],														//The sorting configuration
     legendDisplay: true															//Display the legend
   };
 
-  //Convert the nested data passed in
-  //into an array of values arrays
-  var data = data.map(function(d) { return d.definition; });
+  // Convert the nested data passed in into an array of values arrays
+  var data = input.data.map(function(d) { return d.definition; });
 
-  //Put all of the options into a variable called cfg
+  // Put all of the options into a variable called cfg
   if('undefined' !== typeof options){
     for(var i in options){
       if('undefined' !== typeof options[i]){ cfg[i] = options[i]; }
-    }//for i
-  }//if
+    }
+  }
 
   //If the supplied maxValue is smaller than the actual one, replace by the max in the data
   var maxValue = Math.max(cfg.maxValue, d3.max(data, function(i){return d3.max(i.map(function(o){return o.value;}));}));
@@ -73,12 +71,13 @@ function displayRADAR(className, options, $element, layout, input, self) {
     .domain([minValue, maxValue]);
 
   const rScaleRangeChecked = value => Number.isFinite(value) ? rScale(value) : 0;
+  
   /////////////////////////////////////////////////////////
   //////////// Create the container SVG and g /////////////
   /////////////////////////////////////////////////////////
 
   //Remove whatever chart with the same id/class was present before
-  d3.select(id).select("svg").remove();
+  d3.select(className).select("svg").remove();
 
   const chartContainerElementId = "container_" + layout.qInfo.qId;
  
@@ -88,7 +87,7 @@ function displayRADAR(className, options, $element, layout, input, self) {
     );
   
 
-  var svg = d3.select("#" + id).append("svg")
+  var svg = d3.select("#" + chartContainerElementId).append("svg")
     .attr("width", cfg.size.width)
     .attr("height", cfg.size.height)
     .classed("in-edit-mode", self._inEditState);
@@ -192,7 +191,7 @@ function displayRADAR(className, options, $element, layout, input, self) {
     .style("fill-opacity", cfg.colorOpacity.area)
     .on('mouseover', function (){
       // Make cursor pointer when hovering over blob
-      $("#"+id).css('cursor','pointer');
+      $("#"+chartContainerElementId).css('cursor','pointer');
 
       //Dim all blobs
       d3.selectAll(".radarArea")
@@ -212,12 +211,12 @@ function displayRADAR(className, options, $element, layout, input, self) {
       });
       if(!isNull){
         // Select Value
-        self.backendApi.selectValues(0, [d[0].radar_area_id], true);
+        self.backendApi.selectValues(0, [d[0].radar_areaclassName], true);
       }
     })
     .on('mouseout', function(){
       // keep mouse cursor arrow instead of text select (auto)
-      $("#"+id).css('cursor','default');
+      $("#"+chartContainerElementId).css('cursor','default');
 
       //Bring back all blobs
       d3.selectAll(".radarArea")
@@ -349,7 +348,7 @@ function displayRADAR(className, options, $element, layout, input, self) {
 
   // on mouseover for the legend symbol
   function cellover(d) {
-    $("#"+id).css('cursor','pointer');
+    $("#"+chartContainerElementId).css('cursor','pointer');
 
     //Dim all blobs
     d3.selectAll(".radarArea")
@@ -364,7 +363,7 @@ function displayRADAR(className, options, $element, layout, input, self) {
 
   // on mouseclick for the legend symbol
   function cellclick(d) {
-    $("#"+id).css('cursor','default');
+    $("#"+chartContainerElementId).css('cursor','default');
 
     //Bring back all blobs
     var isNull = false;
@@ -379,13 +378,13 @@ function displayRADAR(className, options, $element, layout, input, self) {
         .style("fill-opacity", 0.9);
 
       // Select Value
-      self.backendApi.selectValues(0, [data[d][0].radar_area_id], true);
+      self.backendApi.selectValues(0, [data[d][0].radar_areaclassName], true);
     }
   }
 
   // on mouseout for the legend symbol
   function cellout() {
-    $("#"+id).css('cursor','default');
+    $("#"+chartContainerElementId).css('cursor','default');
 
     //Bring back all blobs
     d3.selectAll(".radarArea")

--- a/src/radarChart.js
+++ b/src/radarChart.js
@@ -182,9 +182,8 @@ function displayRADAR(className, options, $element, layout, inputData, self) {
   //Append the backgrounds
   blobWrapper
     .append("path")
-  //.attr("class", "radarArea")
     .attr("class", function(d) {
-      return "radarArea" + " c" + d[0].radar_area.replace(/\s+/g, ''); //Remove spaces from the .radar_area string to make one valid class name
+      return "radarArea" + " c" + getValidCssClassName(d[0].radar_area);
     })
     .attr("d", function(d) { return radarLine(d); })
     .style("fill", function(d,i) { return cfg.color(i); })
@@ -356,7 +355,7 @@ function displayRADAR(className, options, $element, layout, inputData, self) {
       .style("fill-opacity", cfg.colorOpacity.area_out);
 
     //Bring back the hovered over blob
-    d3.select(".c" + data[d][0].radar_area.replace(/\s+/g, ''))
+    d3.select(".c" + getValidCssClassName(data[d][0].radar_area))
       .transition().duration(200)
       .style("fill-opacity", cfg.colorOpacity.area_over);
   }
@@ -501,3 +500,10 @@ function renderInvalidMessage ($element) {
 }
   
 export default displayRADAR;
+
+export function getValidCssClassName (input) {
+  if (!input) {
+    return '';
+  }
+  return input.replace(/\s|\/|:/g, '');
+}

--- a/src/radarChart.js
+++ b/src/radarChart.js
@@ -9,7 +9,15 @@ import $ from 'jquery';
 import d3 from 'd3';
 import 'd3-svg-legend';
 
-function displayRADAR(id, options, $element, layout, data, self) {
+const invalidMessageClassName = 'invalid-visualisation-message';
+
+function displayRADAR(className, options, $element, layout, input, self) {
+  const isInvalidVisualisation = !input.isValid;
+  if (isInvalidVisualisation) {
+    renderInvalidMessage($element, input);
+    return;
+  }
+
   var cfg = {
     size: { width: 450, height: 450 },											//Width and Height of the circle
     margin: { top: 100, right: 100, bottom: 100, left: 100 }, 					//The margins around the circle
@@ -489,4 +497,18 @@ Dual licensed under the MIT or GPL Version 2 licenses.
   }
 }
 
+function renderInvalidMessage ($element, { hasInvalidMetricValue, hasAllValuesAsZeros }) {
+  let errorMessage = '';
+  if (hasInvalidMetricValue) {
+    errorMessage = 'The chart is not displayed because there might be an error with the data or the measure.';
+  }
+  if (hasAllValuesAsZeros) {
+    errorMessage = 'The chart is not displayed because there are only zero values.';
+  }
+  let invalidMessageElement = document.createElement('div');
+  invalidMessageElement.className = invalidMessageClassName;
+  invalidMessageElement.innerText = errorMessage;
+  $element.empty().append(invalidMessageElement);
+}
+  
 export default displayRADAR;

--- a/src/radarChart.spec.js
+++ b/src/radarChart.spec.js
@@ -1,0 +1,14 @@
+import { getValidCssClassName } from './radarChart';
+
+describe('getSafeClassName', () => {
+  const input = [
+    { raw: '5/24/2018 9:34:34 AM', expected: '524201893434AM' },
+    { raw: '   s      o   m e where over the rainbow ', expected: 'somewhereovertherainbow' }
+  ];
+
+  input.forEach(({ raw, expected }) => {
+    it(`should convert dates to valid class names from ${raw} to ${expected}`, () => {
+      expect(getValidCssClassName(raw)).toEqual(expected);
+    });
+  });
+});

--- a/src/styles.less
+++ b/src/styles.less
@@ -1,3 +1,11 @@
 .in-edit-mode{
   pointer-events: none;
 }
+
+.invalid-visualisation-message {
+  display: flex;
+  font-size: 1.2em;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}


### PR DESCRIPTION
https://tretton37.atlassian.net/browse/QPE-579

Handle typos/errors from invalid input on measure better, show error message when it doesn't make sense to render.

A1)
To replicate:
1. Enter correct values and verify that we render the radar chart
2. Make a typo in the measure (eg: unicorns, Avg(happiness))
Note that there is an known limitation & edge case when you select either Sum() or Count() then all metric values will be 0 and thus render a chart

Previously: render "NaN" values and on legends hover there is a console error
Now: error message is shown to user about the problem, no chart is rendered

A2)
Other test case:
1. Having the same chart, correct the typo so it's valid data
2. Make sure that the error message is gone and we render a radar chart

B) Dates
1. Have a valid chart that has dates as the first dimension
2. Hover over any of the legend items

Previously: console.errors as it was looking for an invalid css class name 
Now: no errors


