### PR TITLE
fix: disable formatting options with and without flag MASTER_MEASURE_FORMAT

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,37 @@ function setInitialSort(props) {
   }
 }
 
+const numberFormattingItems = {
+  numberFormattingMode: {
+    show: false
+  },
+  numberFormattingType: {
+    options: function() {
+      return [
+        {
+          value: "U",
+          translation: "Common.Auto"
+        },
+        {
+          value: "F",
+          translation: "properties.numberFormatting.types.number"
+        },
+      ];
+    }
+  }
+};
+
+const numberFormatting = {
+  items: {
+    numberFormat: {
+      items: numberFormattingItems
+    }
+  },
+};
+
+// Support without flag MASTER_MEASURE_FORMAT (remove line below when flag becomes permanent)
+Object.assign(numberFormatting.items, Object.assign({}, numberFormattingItems));
+
 export default {
   initialProperties: {
     qHyperCubeDef: {
@@ -111,27 +142,7 @@ export default {
           measures: {
             disabledRef: "",
             items: {
-              numberFormatting: {
-                items: {
-                  numberFormattingMode: {
-                    show: false
-                  },
-                  numberFormattingType: {
-                    options: function() {
-                      return [
-                        {
-                          value: "U",
-                          translation: "Common.Auto"
-                        },
-                        {
-                          value: "F",
-                          translation: "properties.numberFormatting.types.number"
-                        },
-                      ];
-                    }
-                  },
-                }
-              }
+              numberFormatting: numberFormatting
             }
           }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ const numberFormattingItems = {
     show: false
   },
   numberFormattingType: {
+    type: "items", // prevent console warning about missing type
     options: function() {
       return [
         {
@@ -78,8 +79,10 @@ const numberFormattingItems = {
 };
 
 const numberFormatting = {
+  type: "items",
   items: {
     numberFormat: {
+      type: "items",
       items: numberFormattingItems
     }
   },
@@ -146,145 +149,145 @@ export default {
             }
           }
         }
-      }
-    },
-    settings: {
-      uses: "settings",
-      items: {
-        design: {
-          label: "Design",
-          type: "items",
-          items: {
-            Line: {
-              ref: "strokeStyle",
-              component: "dropdown",
-              type: "boolean",
-              label: "Stroke type",
-              defaultValue: true,
-              options: [{
-                value: true,
-                label: "Smooth"
-              }, {
-                value: false,
-                label: "Straight"
-              }],
-              show: true
-            },
-            Range: {
-              ref: "range",
-              component: "switch",
-              type: "boolean",
-              translation: "Range",
-              defaultValue: true,
-              trueOption: {
-                value: true,
-                translation: "Auto"
-              },
-              falseOption: {
-                value: false,
-                translation: "Custom"
-              },
-              show: true
-            },
-            MaxValue: {
-              ref: "maxValue",
-              type: "number",
-              expression: "optional",
-              defaultValue: 1,
-              show: function(data) {
-                return data.range === false;
-              }
-            },
-            MinValue: {
-              ref: "minValue",
-              type: "number",
-              expression: "optional",
-              defaultValue: 0,
-              show: function(data) {
-                return data.range === false;
-              }
-            },
-            Legend: {
-              ref: "showLegend",
-              component: "switch",
-              type: "boolean",
-              translation: "Legend",
-              defaultValue: true,
-              trueOption: {
-                value: true,
-                translation: "properties.on"
-              },
-              falseOption: {
-                value: false,
-                translation: "properties.off"
-              },
-              show: true
-            },
-            colors: {
-              ref: "ColorSchema",
-              type: "string",
-              component: "item-selection-list",
-              label: "Color",
-              show: true,
-              defaultValue: COLOR_SCALES.TWELVE_COLORS,
-              items: [
-                /*{
-                      component: "color-scale",
-                      colors: COLOR_SCALES.SEQUENTIAL,
-                      value: COLOR_SCALES.SEQUENTIAL,
-                      label: "Sequential"
-                    }, {
-                      component: "color-scale",
-                      colors: COLOR_SCALES.SEQUENTIAL_REVERSE,
-                      value: COLOR_SCALES.SEQUENTIAL_REVERSE,
-                      label: "Sequential (Reverse)"
-                    }, {
-                      component: "color-scale",
-                      colors: COLOR_SCALES.DIVERGING_RDYLBU,
-                      value: COLOR_SCALES.DIVERGING_RDYLBU,
-                      label: "Diverging RdYlBu"
-                    }, {
-                      component: "color-scale",
-                      colors: COLOR_SCALES.DIVERGING_BUYLRD,
-                      value: COLOR_SCALES.DIVERGING_BUYLRD,
-                      label: "Diverging BuYlRd"
-                    }, {
-                      component: "color-scale",
-                      colors: COLOR_SCALES.BLUES,
-                      value: COLOR_SCALES.BLUES,
-                      label: "Blues"
-                    }, {
-                      component: "color-scale",
-                      colors: COLOR_SCALES.REDS,
-                      value: COLOR_SCALES.REDS,
-                      label: "Reds"
-                    }, {
-                      component: "color-scale",
-                      colors: COLOR_SCALES.YLGNBU,
-                      value: COLOR_SCALES.YLGNBU,
-                      label: "YlGnBu"
-                    },*/ {
-                  component: "color-scale",
-                  colors: COLOR_SCALES.TWELVE_COLORS,
-                  value: COLOR_SCALES.TWELVE_COLORS,
-                  label: "12 colors"
+      },
+      settings: {
+        uses: "settings",
+        items: {
+          design: {
+            label: "Design",
+            type: "items",
+            items: {
+              Line: {
+                ref: "strokeStyle",
+                component: "dropdown",
+                type: "boolean",
+                label: "Stroke type",
+                defaultValue: true,
+                options: [{
+                  value: true,
+                  label: "Smooth"
                 }, {
-                  component: "color-scale",
-                  colors: COLOR_SCALES.TWELVE_COLORS_REVERSE,
-                  value: COLOR_SCALES.TWELVE_COLORS_REVERSE,
-                  label: "12 colors (Reverse)"
-                }, {
-                  component: "color-scale",
-                  colors: COLOR_SCALES.BLUE_PURPLE,
-                  value: COLOR_SCALES.BLUE_PURPLE,
-                  label: "Blue purple colors"
-                }, {
-                  component: "color-scale",
-                  colors: COLOR_SCALES.BREEZE,
-                  value: COLOR_SCALES.BREEZE,
-                  label: "Breeze theme colors"
+                  value: false,
+                  label: "Straight"
+                }],
+                show: true
+              },
+              Range: {
+                ref: "range",
+                component: "switch",
+                type: "boolean",
+                translation: "Range",
+                defaultValue: true,
+                trueOption: {
+                  value: true,
+                  translation: "Auto"
+                },
+                falseOption: {
+                  value: false,
+                  translation: "Custom"
+                },
+                show: true
+              },
+              MaxValue: {
+                ref: "maxValue",
+                type: "number",
+                expression: "optional",
+                defaultValue: 1,
+                show: function(data) {
+                  return data.range === false;
                 }
-              ]
+              },
+              MinValue: {
+                ref: "minValue",
+                type: "number",
+                expression: "optional",
+                defaultValue: 0,
+                show: function(data) {
+                  return data.range === false;
+                }
+              },
+              Legend: {
+                ref: "showLegend",
+                component: "switch",
+                type: "boolean",
+                translation: "Legend",
+                defaultValue: true,
+                trueOption: {
+                  value: true,
+                  translation: "properties.on"
+                },
+                falseOption: {
+                  value: false,
+                  translation: "properties.off"
+                },
+                show: true
+              },
+              colors: {
+                ref: "ColorSchema",
+                type: "string",
+                component: "item-selection-list",
+                label: "Color",
+                show: true,
+                defaultValue: COLOR_SCALES.TWELVE_COLORS,
+                items: [
+                  /*{
+                    component: "color-scale",
+                    colors: COLOR_SCALES.SEQUENTIAL,
+                    value: COLOR_SCALES.SEQUENTIAL,
+                    label: "Sequential"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.SEQUENTIAL_REVERSE,
+                    value: COLOR_SCALES.SEQUENTIAL_REVERSE,
+                    label: "Sequential (Reverse)"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.DIVERGING_RDYLBU,
+                    value: COLOR_SCALES.DIVERGING_RDYLBU,
+                    label: "Diverging RdYlBu"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.DIVERGING_BUYLRD,
+                    value: COLOR_SCALES.DIVERGING_BUYLRD,
+                    label: "Diverging BuYlRd"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.BLUES,
+                    value: COLOR_SCALES.BLUES,
+                    label: "Blues"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.REDS,
+                    value: COLOR_SCALES.REDS,
+                    label: "Reds"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.YLGNBU,
+                    value: COLOR_SCALES.YLGNBU,
+                    label: "YlGnBu"
+                  },*/ {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.TWELVE_COLORS,
+                    value: COLOR_SCALES.TWELVE_COLORS,
+                    label: "12 colors"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.TWELVE_COLORS_REVERSE,
+                    value: COLOR_SCALES.TWELVE_COLORS_REVERSE,
+                    label: "12 colors (Reverse)"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.BLUE_PURPLE,
+                    value: COLOR_SCALES.BLUE_PURPLE,
+                    label: "Blue purple colors"
+                  }, {
+                    component: "color-scale",
+                    colors: COLOR_SCALES.BREEZE,
+                    value: COLOR_SCALES.BREEZE,
+                    label: "Breeze theme colors"
+                  }
+                ]
+              }
             }
           }
         }
@@ -300,7 +303,7 @@ export default {
           },
           paragraph1: {
             label: `Radar chart is a two-dimensional chart that uses radical axes to show the
-                  scoring of a measure in one dimension over another.`,
+              scoring of a measure in one dimension over another.`,
             component: 'text'
           },
           paragraph2: {


### PR DESCRIPTION
#### Problem
Number formatting options are not overridden as they should (fix for QB-2081) when flag is MASTER_MEASURE_FORMAT turned on due to a new Property Panel definition structure.

#### Solution
This PR adds keeps the options as they are but in addition adds them to the new tree structure (which only exists when the flag is on). Thereby, it does not need to check the flag's state inside of the extension.